### PR TITLE
ci: fix test workflow and add release workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,40 +1,38 @@
 name: Test
-on:
-  workflow_dispatch:
 
-env:
-  # go needs absolute directories, using the $HOME variable doesn't work here.
-  GOCACHE: /home/runner/work/go/pkg/build
-  GOPATH: /home/runner/work/go
-  GO_VERSION: 1.18
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
-  test-cover:
-    name: Unit coverage
+  test:
+    name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - name: Check out source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      #- name: Test
-      #  run: make unit-cover
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests with coverage
+        run: make test-cover
 
   test-race:
-    name: Unit race
+    name: Race detector
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - name: Check out source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      #- name: Test
-      #  run: make unit-race
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests with race detector
+        run: make test-race

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: make test
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git tag --sort=-version:refname | sed -n '2p')
+          if [ -z "$PREV_TAG" ]; then
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" HEAD)
+          else
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD")
+          fi
+          {
+            echo "changelog<<EOF"
+            echo "$CHANGELOG"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: |
+            ## Changes
+
+            ${{ steps.changelog.outputs.changelog }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

- Fix the test workflow (`go.yml`) to trigger on master push/PR instead of manual dispatch only
- Upgrade GitHub Actions to latest versions (checkout@v4, setup-go@v5)
- Use `go-version-file: go.mod` instead of hardcoded Go 1.18
- Enable test steps that were commented out, using Makefile targets
- Add new release workflow that creates a GitHub Release with auto-generated changelog when a `v*.*.*` tag is pushed

## Test plan

- [x] Push to master triggers test workflow
- [x] PR to master triggers test workflow
- [x] Push a `v*.*.*` tag triggers release workflow and creates a GitHub Release