### PR TITLE
feat: add Broadcast.FeedPublish for witness price feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ if err != nil {
 fmt.Println("✅ Vote submitted successfully!")
 ```
 
+### Witness Price Feed
+
+```go
+import "github.com/steemit/steemgosdk/broadcast"
+
+// Publish a witness price feed (requires active private key, not block signing key)
+bc := client.GetBroadcast()
+rate := broadcast.ExchangeRate{
+    Base:  "0.500 SBD",
+    Quote: "1.000 STEEM",
+}
+result, err := bc.FeedPublish("your-witness-account", rate, "your-active-private-key")
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("✅ Price feed published: %s\n", string(result))
+```
+
 ### Authenticated Calls (SignedCall)
 
 ```go

--- a/broadcast/broadcast.go
+++ b/broadcast/broadcast.go
@@ -323,3 +323,24 @@ func (b *Broadcast) CustomJson(requiredAuths, requiredPostingAuths []string, id,
 
 	return b.Send([]protocol.Operation{op}, privKeys)
 }
+
+// ExchangeRate is the exchange_rate payload for feed_publish.
+type ExchangeRate struct {
+	Base  string // e.g. "0.500 SBD"
+	Quote string // e.g. "1.000 STEEM"
+}
+
+// FeedPublish broadcasts a feed_publish operation for a witness price feed.
+// privKeyWif must be the publisher account's active or owner private key (WIF format).
+// Witness block signing keys cannot be used for this operation.
+func (b *Broadcast) FeedPublish(publisher string, rate ExchangeRate, privKeyWif string) ([]byte, error) {
+	op := buildFeedPublishOperation(publisher, rate)
+	return b.SendWith(op, privKeyWif)
+}
+
+func buildFeedPublishOperation(publisher string, rate ExchangeRate) *protocol.FeedPublishOperation {
+	op := &protocol.FeedPublishOperation{Publisher: publisher}
+	op.ExchangeRate.Base = rate.Base
+	op.ExchangeRate.Quote = rate.Quote
+	return op
+}

--- a/broadcast/feed_publish_test.go
+++ b/broadcast/feed_publish_test.go
@@ -1,0 +1,37 @@
+package broadcast
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/steemit/steemutil/protocol"
+)
+
+func TestFeedPublishOperationFields(t *testing.T) {
+	op := buildFeedPublishOperation("witness1", ExchangeRate{
+		Base:  "0.500 SBD",
+		Quote: "1.000 STEEM",
+	})
+
+	if op.Publisher != "witness1" {
+		t.Fatalf("publisher = %q, want witness1", op.Publisher)
+	}
+	if op.ExchangeRate.Base != "0.500 SBD" {
+		t.Fatalf("base = %q, want 0.500 SBD", op.ExchangeRate.Base)
+	}
+	if op.ExchangeRate.Quote != "1.000 STEEM" {
+		t.Fatalf("quote = %q, want 1.000 STEEM", op.ExchangeRate.Quote)
+	}
+	if op.Type() != protocol.TypeFeedPublish {
+		t.Fatalf("type = %q, want %q", op.Type(), protocol.TypeFeedPublish)
+	}
+
+	data, err := json.Marshal(op)
+	if err != nil {
+		t.Fatalf("marshal operation: %v", err)
+	}
+	payload := string(data)
+	if payload == "" {
+		t.Fatal("expected non-empty JSON payload")
+	}
+}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1433,6 +1433,38 @@ func main() {
 }
 ```
 
+### Witness Price Feed (feed_publish)
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/steemit/steemgosdk"
+    "github.com/steemit/steemgosdk/broadcast"
+)
+
+func main() {
+    client := steemgosdk.GetClient("https://api.steemit.com")
+    bc := client.GetBroadcast()
+
+    rate := broadcast.ExchangeRate{
+        Base:  "0.500 SBD",
+        Quote: "1.000 STEEM",
+    }
+
+    // Use the witness account active key (WIF). Block signing keys cannot sign feed_publish.
+    result, err := bc.FeedPublish("your-witness-account", rate, "your-active-private-key")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("feed_publish result: %s\n", string(result))
+}
+```
+
 ## Notes
 
 - **Security**: Never hardcode private keys or passwords in production code. Use environment variables or secure key management systems.


### PR DESCRIPTION
## Summary
- Add `broadcast.ExchangeRate` and `Broadcast.FeedPublish()` for witness price feed publishing
- Document usage in README and docs/examples.md
- Add unit test for feed_publish operation fields

## Test plan
- [x] `go test ./broadcast/...`