### PR TITLE
chore: bump steemutil to v0.0.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/steemit/steemgosdk
 
 go 1.18
 
-require github.com/steemit/steemutil v0.0.20
+require github.com/steemit/steemutil v0.0.21
 
 require github.com/pkg/errors v0.9.1
 

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/steemit/steemutil v0.0.20 h1:0CCxeUzICMW5PfrDN2wRhjm/Vne3RX976rpEVRdksNs=
-github.com/steemit/steemutil v0.0.20/go.mod h1:juhYy3fdFrfG8dXARzQcnTIk0bsDGNAro+9IZJRxa3s=
+github.com/steemit/steemutil v0.0.21 h1:C/dPnhIzNPGiSXRvIlus+JOJDPDjVSm6RmbLMq+vDh4=
+github.com/steemit/steemutil v0.0.21/go.mod h1:juhYy3fdFrfG8dXARzQcnTIk0bsDGNAro+9IZJRxa3s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=


### PR DESCRIPTION
## Summary
- Bump `github.com/steemit/steemutil` from v0.0.20 to v0.0.21

## Motivation
steemutil v0.0.21 fixes `comment_options` extension unmarshaling for condenser API static_variant tuples.

## Test plan
- [x] `go test ./...`